### PR TITLE
Add "System Audio" capture source

### DIFF
--- a/TransFlow/TransFlow/Localizable.xcstrings
+++ b/TransFlow/TransFlow/Localizable.xcstrings
@@ -254,6 +254,23 @@
         }
       }
     },
+    "control.system_audio" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System Audio"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系统音频"
+          }
+        }
+      }
+    },
     "control.start_recording" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/TransFlow/TransFlow/Models/TranscriptionModels.swift
+++ b/TransFlow/TransFlow/Models/TranscriptionModels.swift
@@ -32,6 +32,7 @@ enum ListeningState: Sendable, Equatable {
 /// Audio source type selection.
 enum AudioSourceType: Sendable, Equatable, Hashable {
     case microphone
+    case systemAudio
     case appAudio(AppAudioTarget?)
 }
 

--- a/TransFlow/TransFlow/Services/AppAudioCaptureService.swift
+++ b/TransFlow/TransFlow/Services/AppAudioCaptureService.swift
@@ -148,13 +148,73 @@ final class AppAudioCaptureService: NSObject, Sendable {
         return (handler.audioStream, stop)
     }
 
+    /// Start capturing audio from all applications (system-wide).
+    static func startSystemCapture() async throws -> (stream: AsyncStream<AudioChunk>, stop: @Sendable () -> Void) {
+        let content = try await SCShareableContent.excludingDesktopWindows(
+            false, onScreenWindowsOnly: false
+        )
+
+        guard let display = content.displays.first else {
+            throw CaptureError.noDisplay
+        }
+
+        let currentBundleID = Bundle.main.bundleIdentifier ?? ""
+        let allApps = content.applications.filter { $0.bundleIdentifier != currentBundleID }
+
+        let filter = SCContentFilter(
+            display: display,
+            including: allApps,
+            exceptingWindows: []
+        )
+
+        let config = SCStreamConfiguration()
+        config.capturesAudio = true
+        config.excludesCurrentProcessAudio = true
+        config.sampleRate = 48_000
+        config.channelCount = 1
+        config.width = 2
+        config.height = 2
+        config.minimumFrameInterval = CMTime(value: 1, timescale: 1)
+        config.showsCursor = false
+
+        let scStream = SCStream(filter: filter, configuration: config, delegate: nil)
+
+        let handler = AudioStreamHandler(targetSampleRate: targetSampleRate)
+
+        try scStream.addStreamOutput(
+            handler,
+            type: .audio,
+            sampleHandlerQueue: DispatchQueue.global(qos: .userInteractive)
+        )
+        try scStream.addStreamOutput(
+            handler,
+            type: .screen,
+            sampleHandlerQueue: nil
+        )
+
+        try await scStream.startCapture()
+
+        nonisolated(unsafe) let capturedStream = scStream
+        let stop: @Sendable () -> Void = {
+            Task {
+                try? await capturedStream.stopCapture()
+            }
+            handler.finish()
+        }
+
+        return (handler.audioStream, stop)
+    }
+
     enum CaptureError: Error, LocalizedError {
         case appNotFound
+        case noDisplay
 
         var errorDescription: String? {
             switch self {
             case .appNotFound:
                 "Target application not found"
+            case .noDisplay:
+                "No display available for capture"
             }
         }
     }

--- a/TransFlow/TransFlow/ViewModels/TransFlowViewModel.swift
+++ b/TransFlow/TransFlow/ViewModels/TransFlowViewModel.swift
@@ -145,6 +145,11 @@ final class TransFlowViewModel {
                     audioStream = capture.stream
                     stop = capture.stop
 
+                case .systemAudio:
+                    let capture = try await AppAudioCaptureService.startSystemCapture()
+                    audioStream = capture.stream
+                    stop = capture.stop
+
                 case .appAudio(let target):
                     guard let target else {
                         errorMessage = "No app selected"

--- a/TransFlow/TransFlow/Views/ControlBarView.swift
+++ b/TransFlow/TransFlow/Views/ControlBarView.swift
@@ -190,11 +190,14 @@ struct ControlBarView: View {
                     Button {
                         viewModel.audioSource = .appAudio(app)
                     } label: {
-                        HStack {
-                            Text(app.name)
-                            if case .appAudio(let target) = viewModel.audioSource, target?.id == app.id {
-                                Image(systemName: "checkmark")
-                            }
+                        if let iconData = app.iconData,
+                           let nsImage = NSImage(data: iconData) {
+                            Label { Text(app.name) } icon: { Image(nsImage: nsImage) }
+                        } else {
+                            Label(app.name, systemImage: "app.fill")
+                        }
+                        if case .appAudio(let target) = viewModel.audioSource, target?.id == app.id {
+                            Image(systemName: "checkmark")
                         }
                     }
                 }

--- a/TransFlow/TransFlow/Views/ControlBarView.swift
+++ b/TransFlow/TransFlow/Views/ControlBarView.swift
@@ -172,6 +172,15 @@ struct ControlBarView: View {
                 }
             }
 
+            Button {
+                viewModel.audioSource = .systemAudio
+            } label: {
+                Label("control.system_audio", systemImage: "speaker.wave.2.fill")
+                if case .systemAudio = viewModel.audioSource {
+                    Image(systemName: "checkmark")
+                }
+            }
+
             Divider()
 
             if viewModel.availableApps.isEmpty {
@@ -226,6 +235,9 @@ struct ControlBarView: View {
         case .microphone:
             Image(systemName: "mic.fill")
                 .font(.system(size: 12, weight: .medium))
+        case .systemAudio:
+            Image(systemName: "speaker.wave.2.fill")
+                .font(.system(size: 12, weight: .medium))
         case .appAudio(let target):
             if let target, let iconData = target.iconData,
                let nsImage = NSImage(data: iconData) {
@@ -243,6 +255,7 @@ struct ControlBarView: View {
     private var audioSourceName: String {
         switch viewModel.audioSource {
         case .microphone: String(localized: "control.microphone")
+        case .systemAudio: String(localized: "control.system_audio")
         case .appAudio(let target): target?.name ?? String(localized: "control.app")
         }
     }

--- a/specs/024-all-system-audio/spec.md
+++ b/specs/024-all-system-audio/spec.md
@@ -1,0 +1,51 @@
+# 024 — All System Audio Capture
+
+## Background
+
+Currently, users must select a specific app from the list to capture system audio. This adds an "All System Audio" option (similar to Apple Live Captions' "Computer Audio") that captures audio from all applications at once without needing to pick one.
+
+---
+
+## Model
+
+- [ ] Add `.systemAudio` case to `AudioSourceType`
+
+```swift
+enum AudioSourceType: Sendable, Equatable, Hashable {
+    case microphone
+    case systemAudio
+    case appAudio(AppAudioTarget?)
+}
+```
+
+## Service
+
+- [ ] Add `startSystemCapture()` to `AppAudioCaptureService`
+  - Use `SCContentFilter` with the primary display and all applications included
+  - Exclude TransFlow itself via `excludesCurrentProcessAudio = true`
+  - Reuse the existing `AudioStreamHandler` for 48kHz → 16kHz conversion
+  - Return type matches `startCapture(for:)`: `(stream: AsyncStream<AudioChunk>, stop: @Sendable () -> Void)`
+
+## ViewModel
+
+- [ ] Add `.systemAudio` branch in `TransFlowViewModel.startListening()` switch, calling `AppAudioCaptureService.startSystemCapture()`
+
+## UI
+
+- [ ] Add "System Audio" option in `ControlBarView.audioSourcePicker` menu, between Microphone and the app list divider
+  - Icon: `speaker.wave.2.fill`
+  - Sets `viewModel.audioSource = .systemAudio`
+  - Checkmark logic same as existing items
+- [ ] Update `audioSourceIconView` and `audioSourceName` to handle `.systemAudio`
+
+## i18n
+
+- [ ] Add key `control.system_audio` — en: "System Audio" / zh-Hans: "系统音频"
+
+---
+
+## Out of scope
+
+- Hot-swapping audio sources while transcription is active (stop/start still required)
+- Auto-detection of audio activity to switch between system audio and microphone
+- Persisting audio source selection across launches


### PR DESCRIPTION
## Summary

- Add a "System Audio" option to the audio source picker that captures audio from all applications at once using ScreenCaptureKit, removing the need to select a specific app (similar to Apple Live Captions' "Computer Audio")
- Show app icons in the audio source picker menu for easier identification

## Changes

- **Model**: New `.systemAudio` case on `AudioSourceType`
- **Service**: New `AppAudioCaptureService.startSystemCapture()` using `SCContentFilter` with all apps included
- **ViewModel**: Wire `.systemAudio` in `startListening()` switch
- **UI**: "System Audio" menu item with `speaker.wave.2.fill` icon; app list now shows each app's icon
- **i18n**: `control.system_audio` — en: "System Audio" / zh-Hans: "系统音频"

## Test plan

- [ ] Select "System Audio", start transcription, play audio from any app — verify it is captured and transcribed
- [ ] Switch to a different app producing audio — verify it is also captured without restarting
- [ ] Verify app icons display correctly in the source picker menu
- [ ] Verify Microphone and per-app capture still work as before

## Demo
<img width="190" height="642" alt="image" src="https://github.com/user-attachments/assets/614cb0fd-9eb4-4579-9751-f517e087b5eb" />
